### PR TITLE
Kleine Anpassungen

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ The script is automatically triggered, when the backup-HDD is attached to the Tr
   - -h show help
   - -f force scrub (even if the condition, number of passed days) is not met
   - -d dry run (do not do the actual backup)
+  - -y don't ask when creating/overwriting folders in backup (caution: intended to be used on initial backups; could cause data loss on existing backup data)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ The script is automatically triggered, when the backup-HDD is attached to the Tr
 
 ## Usage
 - configure the devd-rule, and change the config in truenas-poolbackup-conf.env to suit your needs
+- place the script on a safe place in your datapool (as the system partition is not upgrade safe)
 - you may run the script manually, there are parameters available:
   - -h show help
   - -f force scrub (even if the condition, number of passed days) is not met
   - -d dry run (do not do the actual backup)
   - -y don't ask when creating/overwriting folders in backup (caution: intended to be used on initial backups; could cause data loss on existing backup data)
+- execute truenas-copy-devdconf.sh to enable auto backup when configured HDD is attached

--- a/devd-backuphdd.conf
+++ b/devd-backuphdd.conf
@@ -1,16 +1,17 @@
 /*****************************************************************
 devd-config, which triggers the Pool-Backup script, when the Backup USB HDD is attached
 script in /usr/local/etc/devd/ doesn't survive a reboot
-so copy it from /root/scripts/devd/ to /usr/local/etc/devd/ with init-script - truenas-copy-devdconf.sh
+so copy it to /usr/local/etc/devd/ with init-script - truenas-copy-devdconf.sh
 
 *******************************************************************
  DO NOT MOFIDY THIS FILE in /usr/local/etc/devd/
- MODIFY IN /root/scripts/devd/
+ MODIFY IN YOUR SCRIPT LOCATION
 *******************************************************************
 
 this one also dosn't work:
 so add dicrectory to: /conf/base/etc/devd.conf
 place in: /root/scripts/devd/
+(truenas-copy-devdconf.sh will do this steps for you)
 It won't survive upgrades though...
 see: https://www.truenas.com/community/threads/devd-conf-keeps-on-getting-reset-on-reboot.6100/
 *******************************************************************
@@ -56,7 +57,7 @@ Example:
 // Backup-USB HDD is attached
 // *******************************
 
-/* don't us  ethis style, as the event is triggered more than once
+/* don't use this style, as the event is triggered more than once
 notify 100 {
 	match "system"		"GEOM";
 	match "subsystem"	"DEV";

--- a/truenas-copy-devdconf.sh
+++ b/truenas-copy-devdconf.sh
@@ -1,8 +1,54 @@
 #!/bin/bash
 
+set -e
+
 # Copy devd-Config files from root-scripts folder to
 # in /usr/local/etc/devd/ , as files thered don't survive a reboot
-# so copy it from /root/scripts/devd/ to /usr/local/etc/devd/ with cronjob and this script
+# so copy it to /usr/local/etc/devd/ with cronjob and this script
 
-cp /root/scripts/devd/* /usr/local/etc/devd/
+force_copy=0
+
+while getopts "fh" opt; do
+	case $opt in
+		f)	force_copy=1
+		;;
+		h) echo "point devd to a user config dir an copy over the .conf file"
+	 	  	echo "usage: $0 [-fh]"
+	    	echo "Options: -f force copy (replace existing config)"
+	 		echo "         -h print this help and exit"
+			exit 0 ;;
+	esac
+done
+
+if [ -f /usr/local/etc/devd/devd-backuphdd.conf ];
+    then
+        echo "devd-Config found in /usr/local/etc/devd"
+        if [ $force_copy -eq 1 ];
+            then
+                echo "force_copy option is used. Overwriting config..."
+        else
+            echo "Use '-f' option to overwrite if needed."
+            exit 0
+        fi
+fi
+
+
+SCRIPT_PATH="`dirname \"$0\"`"
+SCRIPT_PATH="`( cd \"$SCRIPT_PATH\" && pwd )`"
+
+
+# Add Config dir if not set
+if [ ! -d /usr/local/etc/devd ];
+    then
+        mkdir -p /usr/local/etc/devd
+fi
+if [ $(grep -c 'directory "/usr/local/etc/devd";' /conf/base/etc/devd.conf) -eq 0 ];
+    then
+        sed -i'.backup' '/pid-file.*/i \   
+        directory "/usr/local/etc/devd";
+' /conf/base/etc/devd.conf
+fi
+
+# Copy Config
+cp ${SCRIPT_PATH}/devd-backuphdd.conf /usr/local/etc/devd/
 /etc/rc.d/devd restart

--- a/truenas-poolbackup-conf-example.env
+++ b/truenas-poolbackup-conf-example.env
@@ -1,14 +1,25 @@
 # Example file "truenas-poolbackup-conf-example.env" provided - rename to truenas-poolbackup-conf.env
 
+
 # Pool to be saved
+
 MASTERPOOL="Data"
 
+
 # Backup-Pool (on HD)
-# Bsp. für Test: Ext-Test
+
+# - Name of the created ZFS pool on HD
 BACKUPPOOL="Ext-Backup"
+
+# - Keyfile for encrypted ZFS; leave blank "" if you don't use this feature
 BACKUPKEY="/root/scripts/keys/Ext-Backup-key.key"
+
+
+# Logging
+
 TIMESTAMP=`date +"%Y-%m-%d_%H-%M-%S"`
 BACKUPLOG="/root/scripts/logs/$TIMESTAMP-backup.log"
+
 
 # Datasets, which should be included in the Backup (Child dataset are added automatically)
 MAINDATASETS=("test-set1" "test-set2")
@@ -17,7 +28,7 @@ MAINDATASETS=("test-set1" "test-set2")
 KEEPOLD=2
 
 # Prefix for Snapshot-Name
-PREFIX="back-script" # Backup-Script
+PREFIX="back-script"
 
 # Email for notifications
-email="email@host.com" # receiver #here
+email="email@host.com" # receives the notification

--- a/truenas-poolbackup.sh
+++ b/truenas-poolbackup.sh
@@ -61,8 +61,13 @@ while getopts "hdfm:" opt; do
 done
 
 # --------------- wait to be able to kill process  --------------
-echo "Sleeping for 60 sec. - so you can kill me"
-sleep 60
+secs=0
+while [ ! 60 -eq $secs ]; do
+    sleep 1
+    ((secs=secs+1))
+	echo -ne "Sleeping for 60 sec. - so you can kill me ($secs) "\\r
+done
+echo
 echo "Starting..."
 
 # ######################################################################
@@ -109,8 +114,8 @@ done
 
 # Logfile
 if [ $dry_run -eq 1 ]; then
- echo "########## DRYRUN##########" >> ${BACKUPLOG}
- echo "########## DRYRUN##########"
+ echo "########## DRYRUN ##########" >> ${BACKUPLOG}
+ echo "########## DRYRUN ##########"
 fi
  echo "########## Backup of pools on server ${freenashost} ##########" >> ${BACKUPLOG}
  echo "Started Backup-job: $TIMESTAMP" >> ${BACKUPLOG}
@@ -146,7 +151,8 @@ zfs load-key -r $BACKUPPOOL < $BACKUPKEY
 zpool status $BACKUPPOOL >> ${BACKUPLOG}
 
 # Check if one of the pools has problems
-condition=$(zpool status | egrep -i '(DEGRADED|FAULTED|OFFLINE|UNAVAIL|REMOVED|FAIL|DESTROYED|corrupt|cannot|unrecover)')
+#condition=$(zpool status | egrep -i '(DEGRADED|FAULTED|OFFLINE|UNAVAIL|REMOVED|FAIL|DESTROYED|corrupt|cannot|unrecover)') # https://github.com/dapuru/zfsbackup/issues/5
+condition=$(zpool status | egrep -i '(DEGRADED|FAULTED|OFFLINE|UNAVAIL|REMOVED|FAIL|DESTROYED|corrupt|cannot|unrecover)' | grep -v "features are unavailable")
 if [ "${condition}" ]; then
   problems=1
   subject="TrueNas - ERR Backup to $BACKUPPOOL $TIMESTAMP"
@@ -176,7 +182,7 @@ do
 	if [ -z "$recentBSnap" ] 
 		then
 			echo "ERROR - No snapshot found..." >> ${BACKUPLOG}
-			dialog --title "No snapshot found" --yesno "There is no backup-snapshot in ${BACKUPPOOL}/${DATASET}. Should a new backup be created? (Existing data in ${BACKUPPOOL}/${DATASET} wwill be overwritten.)" 15 60
+			dialog --title "No snapshot found" --yesno "There is no backup-snapshot in ${BACKUPPOOL}/${DATASET}. Should a new backup be created? (Existing data in ${BACKUPPOOL}/${DATASET} will be overwritten.)" 15 60
 			ANTWORT=${?}
 			if [ "$ANTWORT" -eq "0" ]
 				then

--- a/truenas-poolbackup.sh
+++ b/truenas-poolbackup.sh
@@ -146,8 +146,7 @@ do
 done
 
 
-# Import Backup-
-Pool
+# Import Backup-Pool
 zpool import $BACKUPPOOL
 
 # Unlock Pool (if Keyfile is provideds)

--- a/truenas-poolbackup.sh
+++ b/truenas-poolbackup.sh
@@ -144,8 +144,11 @@ done
 # Import Backup-Pool
 zpool import $BACKUPPOOL
 
-# Unlock Pool
-zfs load-key -r $BACKUPPOOL < $BACKUPKEY
+# Unlock Pool (if Keyfile is provideds)
+if [ ! -z $BACKUPKEY ];
+	then
+		zfs load-key -r $BACKUPPOOL < $BACKUPKEY
+fi
 
 # Log Status pf Backup-Pool
 zpool status $BACKUPPOOL >> ${BACKUPLOG}

--- a/truenas-poolbackup.sh
+++ b/truenas-poolbackup.sh
@@ -44,18 +44,23 @@ set +o allexport
 
 dry_run=0
 force_scrub=0
+yes_all=0
 
-while getopts "hdfm:" opt; do
+while getopts "hdfy" opt; do
 	case $opt in
 		d)	dry_run=1
 		;;
 		f)	force_scrub=1
-		;;		
+		;;
+		y)	yes_all=1
+		;;
 		h) echo "run poolbackup using zfs. Config file in truenas-poolbackup-conf.env"
-	 	  	echo 'usage: truenas-poolbackup [-dfh]'
+	 	  	echo 'usage: truenas-poolbackup [-dfhy]'
 	    	echo "Options: -d dryrun (no backup done)"
 	    	echo "         -f force scrub (even condition is not met)"
 	 		echo "         -h print this help and exit"
+	 		echo "         -y don't ask when creating/overwriting folders in backup"
+			echo "            (caution: intended to be used on initial backups)"
 			exit 0 ;;
 	esac
 done
@@ -185,8 +190,13 @@ do
 	if [ -z "$recentBSnap" ] 
 		then
 			echo "ERROR - No snapshot found..." >> ${BACKUPLOG}
-			dialog --title "No snapshot found" --yesno "There is no backup-snapshot in ${BACKUPPOOL}/${DATASET}. Should a new backup be created? (Existing data in ${BACKUPPOOL}/${DATASET} will be overwritten.)" 15 60
-			ANTWORT=${?}
+			if [ ! $yes_all -eq 1 ];
+				then
+					dialog --title "No snapshot found" --yesno "There is no backup-snapshot in ${BACKUPPOOL}/${DATASET}. Should a new backup be created? (Existing data in ${BACKUPPOOL}/${DATASET} will be overwritten.)" 15 60
+					ANTWORT=${?}
+			else
+				ANTWORT="0"
+			fi
 			if [ "$ANTWORT" -eq "0" ]
 				then
 					# Initialize Backup


### PR DESCRIPTION
Nichts großes... da ich das Skript sehr gut finde, habe ich ein paar kleine Fixes / Erweiterungen gemacht:

- Die Verwendung verschlüsselter Pools ist nun optional
  - bei leerer Keyfile-Option wird der Schritt übersprungen
- Counter für den 60 Sekunden Sleep (ich konnte einfach nicht so lange warten 😉 )
- Hotfix für das fälschliche erkennen eines unsauberen Pools (close #5 )
- Ein paar wenige Tippfehler beseitigt und Whitespaces hinzugefügt
- CLI Option `-y` : Yes To All fragt nicht bei der Erstellung jedes Ordners/Datasets im Backup (close #8 )
